### PR TITLE
Add copyDocument()

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ db.createDatabase(baseUrl, dbName)
 //   duration: 4 }
 ```
 
+#### copy document
+```javascript
+.then(() => db.copyDocument(baseUrl, dbName, 'doc2', 'doc3'))
+.then(console.log)
+// { headers: { ... },
+//   data:
+//    { ok: true,
+//      id: 'doc3',
+//      rev: '1-4c6114c65e295552ab1019e2b046b10e' },
+//   status: 201,
+//   message: 'Created – Document created and stored on disk',
+//   duration: 42 }
+```
+
 #### create document
 ```javascript
 .then(() => db.createDocument(baseUrl, dbName, {name: 'Bob'}))

--- a/index.js
+++ b/index.js
@@ -465,7 +465,7 @@ module.exports = function (opt) {
    * @param  {String} newDocId
    * @return {Promise}
    */
-  couch.copyDocument = function copyDocument(baseUrl, dbName, docId, newDocId) {
+  couch.copyDocument = function copyDocument (baseUrl, dbName, docId, newDocId) {
     if (docId && newDocId) {
       return request({
         headers: { Destination: newDocId },
@@ -479,7 +479,7 @@ module.exports = function (opt) {
           404: 'Not Found – Specified database or document ID doesn’t exists',
           409: 'Conflict – Document with the specified ID already exists or specified revision is not latest for target document'
         }
-      });
+      })
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -66,6 +66,11 @@ module.exports = function (opt) {
       }
     }
 
+    // If passed, propagate Destination header required for HTTP COPY
+    if (param.headers && param.headers.Destination) {
+      httpOptions.headers.Destination = param.headers.Destination
+    }
+
     if (!isValidUrl(url)) {
       return Promise.reject({
         headers: {},
@@ -450,6 +455,32 @@ module.exports = function (opt) {
         404: 'Not Found - Document not found'
       }
     })
+  }
+
+  /**
+   * Copy an existing document to a new document
+   * @param  {String} baseUrl
+   * @param  {String} dbName
+   * @param  {String} docId
+   * @param  {String} newDocId
+   * @return {Promise}
+   */
+  couch.copyDocument = function copyDocument(baseUrl, dbName, docId, newDocId) {
+    if (docId && newDocId) {
+      return request({
+        headers: { Destination: newDocId },
+        url: `${baseUrl}/${encodeURIComponent(dbName)}/${encodeURIComponent(docId)}`,
+        method: 'COPY',
+        statusCodes: {
+          201: 'Created – Document created and stored on disk',
+          202: 'Accepted – Document data accepted, but not yet stored on disk',
+          400: 'Bad Request – Invalid request body or parameters',
+          401: 'Unauthorized – Write privileges required',
+          404: 'Not Found – Specified database or document ID doesn’t exists',
+          409: 'Conflict – Document with the specified ID already exists or specified revision is not latest for target document'
+        }
+      });
+    }
   }
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -179,6 +179,34 @@ test('deleteDatabase() with error', function (t) {
   .catch(response => checkResponse(t, response, 404))   // not found
 })
 
+test('copyDocument() to new doc', function (t) {
+  t.plan(1)
+  const dbName = getName()
+  const doc = {foo: 'bar'}
+  db.createDatabase(baseUrl, dbName)
+  .then(() => db.createDocument(baseUrl, dbName, doc, 'doc'))
+  .then(response => checkResponse(t, response, [201, 202]))
+  .then(() => db.copyDocument(baseUrl, dbName, 'doc', 'doc2'))
+  .then(response => checkResponse(t, response, 201))
+  .then(() => db.deleteDatabase(baseUrl, dbName))
+  .catch(response => console.error(util.inspect(response)))
+})
+
+test('copyDocument() to existing doc with error', function (t) {
+  t.plan(1)
+  const dbName = getName()
+  const doc = {foo: 'bar'}
+  db.createDatabase(baseUrl, dbName)
+  .then(() => db.createDocument(baseUrl, dbName, doc, 'doc'))
+  .then(response => checkResponse(t, response, [201, 202]))
+  .then(() => db.copyDocument(baseUrl, dbName, 'doc', 'doc2'))
+  .then(response => checkResponse(t, response, 201))
+  .then(() => db.copyDocument(baseUrl, dbName, 'doc', 'doc2'))
+  .catch(response => checkResponse(t, response, 409))
+  .then(() => db.deleteDatabase(baseUrl, dbName))
+  .catch(response => console.error(util.inspect(response)))
+})
+
 test('createDocument() without docId', function (t) {
   t.plan(1)
   const dbName = getName()


### PR DESCRIPTION
Implements copyDocument() method based on CouchDB support for HTTP COPY
(https://wiki.apache.org/couchdb/HTTP_Document_API#COPY)